### PR TITLE
Split spooled files listing/reading in two implementations to support pre 7.3 TR 12 LPARs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ibmisteps/model/CLSpooledFilehandler.java
+++ b/src/main/java/org/jenkinsci/plugins/ibmisteps/model/CLSpooledFilehandler.java
@@ -1,0 +1,79 @@
+package org.jenkinsci.plugins.ibmisteps.model;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.jenkinsci.plugins.ibmisteps.model.SpooledFiles.SpooledFile;
+
+import com.ibm.as400.access.AS400SecurityException;
+import com.ibm.as400.access.ErrorCompletingRequestException;
+import com.ibm.as400.access.IFSFile;
+import com.ibm.as400.access.ObjectDoesNotExistException;
+import com.ibm.as400.access.list.OpenListException;
+import com.ibm.as400.access.list.SpooledFileListItem;
+import com.ibm.as400.access.list.SpooledFileOpenList;
+
+import hudson.FilePath;
+
+public class CLSpooledFilehandler implements SpooledFileHandler {
+	private static final long serialVersionUID = -2465788947902207300L;
+
+	CLSpooledFilehandler() {
+
+	}
+
+	@Override
+	public void writeSpooledFile(final IBMi ibmi, final SpooledFile spooledFile, final FilePath toFile)
+			throws IOException, InterruptedException, AS400SecurityException, ErrorCompletingRequestException {
+		final IFSFile workFolder = new IFSFile(ibmi.getIbmiConnection(), "/tmp", UUID.randomUUID() + ".jenkins.temp");
+		try {
+			workFolder.mkdirs();
+			final IFSFile targetFile = new IFSFile(workFolder, spooledFile.getName() + "_" + spooledFile.getNumber() + ".txt");
+			final IFSFile workFile = new IFSFile(workFolder, targetFile.getName() + ".work");
+
+			final CallResult cpysplf = ibmi
+					.executeCommand(String.format(
+							"CPYSPLF FILE(%s) SPLNBR(%s) TOFILE(*TOSTMF) JOB(%s/%s/%s) TOSTMF('%s')",
+							spooledFile.getName(), spooledFile.getNumber(),
+							spooledFile.getJobNumber(), spooledFile.getJobUser(), spooledFile.getJobName(),
+							workFile));
+			if (!cpysplf.isSuccessful()) {
+				throw new IOException("CPYSPLF failed: " + cpysplf.getPrettyMessages());
+			}
+
+			// Convert to UTF-8
+			final CallResult cpy = ibmi
+					.executeCommand(String.format("CPY OBJ('%s') TOOBJ('%s') TOCCSID(1208) DTAFMT(*TEXT)",
+							workFile, targetFile));
+			if (!cpysplf.isSuccessful()) {
+				throw new IOException("CPY failed: " + cpy.getPrettyMessages());
+			}
+
+			ibmi.download(targetFile, toFile);
+		} finally {
+			ibmi.executeCommand(String.format("RMDIR DIR('%s') SUBTREE(*ALL) RMVLNK(*YES)", workFolder));
+		}
+	}
+
+	@Override
+	public SpooledFiles listSpooledFiles(final IBMi ibmi, final String jobNumber, final String jobUser, final String jobName)
+			throws IOException, InterruptedException, AS400SecurityException, ErrorCompletingRequestException, ObjectDoesNotExistException, OpenListException {
+		final SpooledFiles spooledFiles = new SpooledFiles();
+		final SpooledFileOpenList spooledList = new SpooledFileOpenList(ibmi.getIbmiConnection());
+		spooledList.setFilterJobInformation(jobName, jobUser, jobNumber);
+		try {
+			spooledList.open();
+			for (final Object object : spooledList.getItems(-1, 0)) {
+				final SpooledFileListItem spooledFileItem = (SpooledFileListItem) object;
+				final SpooledFile spooledFile = new SpooledFile(spooledFileItem.getName(),
+						spooledFileItem.getNumber(),
+						spooledFileItem.getSize(), spooledFileItem.getUserData(),
+						spooledFileItem.getJobName(), spooledFileItem.getJobUser(), spooledFileItem.getJobNumber());
+				spooledFiles.add(spooledFile);
+			}
+		} finally {
+			spooledList.close();
+		}
+		return spooledFiles;
+	}
+}

--- a/src/main/java/org/jenkinsci/plugins/ibmisteps/model/SQLSpooledFilehandler.java
+++ b/src/main/java/org/jenkinsci/plugins/ibmisteps/model/SQLSpooledFilehandler.java
@@ -35,7 +35,7 @@ public class SQLSpooledFilehandler implements SpooledFileHandler {
 			throws SQLException, AS400SecurityException, ObjectDoesNotExistException, IOException, InterruptedException,
 			ErrorCompletingRequestException {
 		final List<String> content = new ArrayList<>();
-		final String query = String.format(SPOOLED_FILE_DATA,
+		final String query = SPOOLED_FILE_DATA.formatted(
 				spooledFile.getJobNumber(),
 				spooledFile.getJobUser(),
 				spooledFile.getJobName(),
@@ -50,7 +50,7 @@ public class SQLSpooledFilehandler implements SpooledFileHandler {
 			throws SQLException, AS400SecurityException, ObjectDoesNotExistException, IOException, InterruptedException,
 			ErrorCompletingRequestException {
 		final SpooledFiles spooledFiles = new SpooledFiles();
-		ibmi.executeAndProcessQuery(String.format(SPOOLED_FILE_INFO,
+		ibmi.executeAndProcessQuery(SPOOLED_FILE_INFO.formatted(
 				jobNumber,
 				jobUser,
 				jobName),

--- a/src/main/java/org/jenkinsci/plugins/ibmisteps/model/SQLSpooledFilehandler.java
+++ b/src/main/java/org/jenkinsci/plugins/ibmisteps/model/SQLSpooledFilehandler.java
@@ -18,7 +18,7 @@ public class SQLSpooledFilehandler implements SpooledFileHandler {
 	private static final String SPOOLED_FILE_DATA = """
 			Select RTRIM(SPOOLED_DATA) \
 			From TABLE(SYSTOOLS.SPOOLED_FILE_DATA(JOB_NAME =>'%s/%s/%s', SPOOLED_FILE_NAME =>'%s', SPOOLED_FILE_NUMBER => %d)) \
-			Order By ORDINAL_POSITION
+			Order By ORDINAL_POSITION \
 			""";
 
 	private static final String SPOOLED_FILE_INFO = """

--- a/src/main/java/org/jenkinsci/plugins/ibmisteps/model/SQLSpooledFilehandler.java
+++ b/src/main/java/org/jenkinsci/plugins/ibmisteps/model/SQLSpooledFilehandler.java
@@ -16,14 +16,14 @@ public class SQLSpooledFilehandler implements SpooledFileHandler {
 	private static final long serialVersionUID = -115898412769496093L;
 
 	private static final String SPOOLED_FILE_DATA = """
-			Select RTRIM(SPOOLED_DATA)
-			From TABLE(SYSTOOLS.SPOOLED_FILE_DATA(JOB_NAME =>'%s/%s/%s', SPOOLED_FILE_NAME =>'%s', SPOOLED_FILE_NUMBER => %d))
+			Select RTRIM(SPOOLED_DATA) \
+			From TABLE(SYSTOOLS.SPOOLED_FILE_DATA(JOB_NAME =>'%s/%s/%s', SPOOLED_FILE_NAME =>'%s', SPOOLED_FILE_NUMBER => %d)) \
 			Order By ORDINAL_POSITION
 			""";
 
 	private static final String SPOOLED_FILE_INFO = """
-			Select SPOOLED_FILE_NAME, SPOOLED_FILE_NUMBER, SIZE, USER_DATA, JOB_NAME, JOB_USER, JOB_NUMBER
-			From Table(QSYS2.SPOOLED_FILE_INFO(JOB_NAME => '%s/%s/%s', STATUS => '*READY'))
+			Select SPOOLED_FILE_NAME, SPOOLED_FILE_NUMBER, SIZE, USER_DATA, JOB_NAME, JOB_USER, JOB_NUMBER \
+			From Table(QSYS2.SPOOLED_FILE_INFO(JOB_NAME => '%s/%s/%s', STATUS => '*READY')) \
 			""";
 
 	SQLSpooledFilehandler() {

--- a/src/main/java/org/jenkinsci/plugins/ibmisteps/model/SQLSpooledFilehandler.java
+++ b/src/main/java/org/jenkinsci/plugins/ibmisteps/model/SQLSpooledFilehandler.java
@@ -1,0 +1,62 @@
+package org.jenkinsci.plugins.ibmisteps.model;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jenkinsci.plugins.ibmisteps.model.SpooledFiles.SpooledFile;
+
+import com.ibm.as400.access.AS400SecurityException;
+import com.ibm.as400.access.ErrorCompletingRequestException;
+import com.ibm.as400.access.ObjectDoesNotExistException;
+
+import hudson.FilePath;
+
+public class SQLSpooledFilehandler implements SpooledFileHandler {
+	private static final long serialVersionUID = -115898412769496093L;
+
+	SQLSpooledFilehandler() {
+
+	}
+
+	@Override
+	public void writeSpooledFile(final IBMi ibmi, final SpooledFile spooledFile, final FilePath toFile)
+			throws SQLException, AS400SecurityException, ObjectDoesNotExistException, IOException, InterruptedException,
+			ErrorCompletingRequestException {
+		final List<String> content = new ArrayList<>();
+		final String query = String.format("""
+				Select RTRIM(SPOOLED_DATA)
+				From TABLE(SYSTOOLS.SPOOLED_FILE_DATA(JOB_NAME =>'%s/%s/%s', SPOOLED_FILE_NAME =>'%s', SPOOLED_FILE_NUMBER => %d))
+				Order By ORDINAL_POSITION
+				""",
+				spooledFile.getJobNumber(),
+				spooledFile.getJobUser(),
+				spooledFile.getJobName(),
+				spooledFile.getName(),
+				spooledFile.getNumber());
+		ibmi.executeAndProcessQuery(query, row -> content.add(row.getString(1)));
+		toFile.write(String.join("\n", content), StandardCharsets.UTF_8.name());
+	}
+
+	@Override
+	public SpooledFiles listSpooledFiles(final IBMi ibmi, final String jobNumber, final String jobUser, final String jobName)
+			throws SQLException, AS400SecurityException, ObjectDoesNotExistException, IOException, InterruptedException,
+			ErrorCompletingRequestException {
+		final SpooledFiles spooledFiles = new SpooledFiles();
+		ibmi.executeAndProcessQuery(String.format("""
+				Select SPOOLED_FILE_NAME, SPOOLED_FILE_NUMBER, SIZE, USER_DATA, JOB_NAME, JOB_USER, JOB_NUMBER
+				From Table(QSYS2.SPOOLED_FILE_INFO(JOB_NAME => '%s/%s/%s', STATUS => '*READY'))
+				""",
+				jobNumber,
+				jobUser,
+				jobName),
+				row -> spooledFiles.add(new SpooledFile(row.getString("SPOOLED_FILE_NAME"),
+						row.getInt("SPOOLED_FILE_NUMBER"),
+						row.getLong("SIZE"), row.getString("USER_DATA"),
+						row.getString("JOB_NAME"), row.getString("JOB_USER"), row.getString("JOB_NUMBER"))));
+		return spooledFiles;
+	}
+
+}

--- a/src/main/java/org/jenkinsci/plugins/ibmisteps/model/SpooledFileHandler.java
+++ b/src/main/java/org/jenkinsci/plugins/ibmisteps/model/SpooledFileHandler.java
@@ -1,0 +1,25 @@
+package org.jenkinsci.plugins.ibmisteps.model;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.sql.SQLException;
+
+import org.jenkinsci.plugins.ibmisteps.model.SpooledFiles.SpooledFile;
+
+import com.ibm.as400.access.AS400SecurityException;
+import com.ibm.as400.access.ErrorCompletingRequestException;
+import com.ibm.as400.access.ObjectDoesNotExistException;
+import com.ibm.as400.access.list.OpenListException;
+
+import hudson.FilePath;
+
+public interface SpooledFileHandler extends Serializable {
+
+	void writeSpooledFile(IBMi ibmi, SpooledFile spooledFile, FilePath target)
+			throws SQLException, AS400SecurityException, ObjectDoesNotExistException, IOException, InterruptedException,
+			ErrorCompletingRequestException;
+
+	SpooledFiles listSpooledFiles(IBMi ibmi, String jobNumber, String jobUser, String jobName)
+			throws SQLException, AS400SecurityException, ObjectDoesNotExistException, IOException, InterruptedException,
+			ErrorCompletingRequestException, OpenListException;
+}

--- a/src/main/java/org/jenkinsci/plugins/ibmisteps/steps/IBMiGetSAVFStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ibmisteps/steps/IBMiGetSAVFStep.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.ibmisteps.steps;
 import com.ibm.as400.access.AS400SecurityException;
 import com.ibm.as400.access.ErrorCompletingRequestException;
 import com.ibm.as400.access.SaveFile;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.FilePath;
@@ -82,6 +83,7 @@ public class IBMiGetSAVFStep extends IBMiStep<SaveFileContent> {
             return "ibmiGetSAVF";
         }
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.IBMiDownloadSAVF_description();

--- a/src/main/java/org/jenkinsci/plugins/ibmisteps/steps/IBMiGetSpooledFilesStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ibmisteps/steps/IBMiGetSpooledFilesStep.java
@@ -1,14 +1,11 @@
 package org.jenkinsci.plugins.ibmisteps.steps;
 
-import com.ibm.as400.access.AS400SecurityException;
-import com.ibm.as400.access.ErrorCompletingRequestException;
-import com.ibm.as400.access.ObjectDoesNotExistException;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.Extension;
-import hudson.FilePath;
+import java.text.MessageFormat;
+
 import org.jenkinsci.plugins.ibmisteps.Messages;
 import org.jenkinsci.plugins.ibmisteps.model.IBMi;
 import org.jenkinsci.plugins.ibmisteps.model.LoggerWrapper;
+import org.jenkinsci.plugins.ibmisteps.model.SpooledFileHandler;
 import org.jenkinsci.plugins.ibmisteps.model.SpooledFiles;
 import org.jenkinsci.plugins.ibmisteps.steps.abstracts.IBMiStep;
 import org.jenkinsci.plugins.ibmisteps.steps.abstracts.IBMiStepDescriptor;
@@ -16,12 +13,9 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.sql.SQLException;
-import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.List;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.FilePath;
 
 public class IBMiGetSpooledFilesStep extends IBMiStep<SpooledFiles> {
 	private static final long serialVersionUID = 1880307039400864220L;
@@ -34,7 +28,7 @@ public class IBMiGetSpooledFilesStep extends IBMiStep<SpooledFiles> {
 
 	@DataBoundConstructor
 	public IBMiGetSpooledFilesStep(final String jobName, final String jobNumber, final String jobUser,
-	                               final String to) {
+			final String to) {
 		this.jobName = jobName.trim().toUpperCase();
 		this.jobUser = jobUser.trim().toUpperCase();
 		this.jobNumber = jobNumber.trim().toUpperCase();
@@ -70,7 +64,8 @@ public class IBMiGetSpooledFilesStep extends IBMiStep<SpooledFiles> {
 	protected SpooledFiles runOnIBMi(final StepContext stepContext, final LoggerWrapper logger, final IBMi ibmi)
 			throws Exception {
 		logger.log(Messages.IBMiGetSpooledFiles_getting(jobNumber, jobUser, jobName));
-		final SpooledFiles spooledFiles = listSpooledFiles(ibmi);
+		final SpooledFileHandler spooledFileHandler = ibmi.getSpooledFileHandler();
+		final SpooledFiles spooledFiles = spooledFileHandler.listSpooledFiles(ibmi, jobNumber, jobUser, jobName);
 
 		final FilePath toFolder = stepContext.get(FilePath.class).child(to);
 		if (toFolder.exists() && clearTo) {
@@ -82,44 +77,11 @@ public class IBMiGetSpooledFilesStep extends IBMiStep<SpooledFiles> {
 		for (final SpooledFiles.SpooledFile spooledFile : spooledFiles) {
 			final FilePath toFile = toFolder.child(spooledFile.getFileName());
 			logger.trace(MessageFormat.format("Writing {0} ({1}) into {2}", spooledFile.getName(), spooledFile.getNumber(), toFile));
-			toFile.write(readSpooledFile(ibmi, spooledFile), StandardCharsets.UTF_8.name());
+			spooledFileHandler.writeSpooledFile(ibmi, spooledFile, toFile);
 		}
 
 		logger.log(Messages.IBMiGetSpooledFiles_count(spooledFiles.size(), toFolder));
 		return spooledFiles;
-	}
-
-	private SpooledFiles listSpooledFiles(final IBMi ibmi)
-			throws SQLException, AS400SecurityException, ObjectDoesNotExistException, IOException, InterruptedException,
-			ErrorCompletingRequestException {
-		final SpooledFiles spooledFiles = new SpooledFiles();
-		ibmi.executeAndProcessQuery(String.format(
-						"Select SPOOLED_FILE_NAME, SPOOLED_FILE_NUMBER, SIZE, USER_DATA, JOB_NAME, JOB_USER, JOB_NUMBER " +
-								"From Table(QSYS2.SPOOLED_FILE_INFO(JOB_NAME => '%s/%s/%s', STATUS => '*READY'))",
-						jobNumber, jobUser, jobName),
-				row -> {
-					final SpooledFiles.SpooledFile spooledFile = new SpooledFiles.SpooledFile(
-							row.getString("SPOOLED_FILE_NAME"),
-							row.getInt("SPOOLED_FILE_NUMBER"),
-							row.getLong("SIZE"), row.getString("USER_DATA"),
-							row.getString("JOB_NAME"), row.getString("JOB_USER"), row.getString("JOB_NUMBER"));
-
-					if (spooledFile.exists()) {
-						spooledFiles.add(spooledFile);
-					}
-				});
-
-		return spooledFiles;
-	}
-
-	private String readSpooledFile(final IBMi ibmi, final SpooledFiles.SpooledFile spooledFile) throws SQLException, AS400SecurityException, ObjectDoesNotExistException, IOException, InterruptedException, ErrorCompletingRequestException {
-		final List<String> lines = new ArrayList<>();
-		ibmi.executeAndProcessQuery(String.format("select RTRIM(SPOOLED_DATA) from table(SYSTOOLS.spooled_file_data(job_name => '%s/%s/%s', SPOOLED_FILE_NAME => '%s', SPOOLED_FILE_NUMBER => %s))",
-						spooledFile.getJobNumber(), spooledFile.getJobUser(), spooledFile.getJobName(),
-						spooledFile.getName(), spooledFile.getNumber()),
-				row -> lines.add(row.getString(1)));
-
-		return String.join("\n", lines);
 	}
 
 	@Extension

--- a/src/main/java/org/jenkinsci/plugins/ibmisteps/steps/IBMiGetSpooledFilesStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ibmisteps/steps/IBMiGetSpooledFilesStep.java
@@ -2,13 +2,11 @@ package org.jenkinsci.plugins.ibmisteps.steps;
 
 import com.ibm.as400.access.AS400SecurityException;
 import com.ibm.as400.access.ErrorCompletingRequestException;
-import com.ibm.as400.access.IFSFile;
 import com.ibm.as400.access.ObjectDoesNotExistException;
-import hudson.AbortException;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import org.jenkinsci.plugins.ibmisteps.Messages;
-import org.jenkinsci.plugins.ibmisteps.model.CallResult;
 import org.jenkinsci.plugins.ibmisteps.model.IBMi;
 import org.jenkinsci.plugins.ibmisteps.model.LoggerWrapper;
 import org.jenkinsci.plugins.ibmisteps.model.SpooledFiles;
@@ -19,146 +17,123 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.text.MessageFormat;
-import java.util.UUID;
+import java.util.ArrayList;
+import java.util.List;
 
 public class IBMiGetSpooledFilesStep extends IBMiStep<SpooledFiles> {
-    private static final long serialVersionUID = 1880307039400864220L;
+	private static final long serialVersionUID = 1880307039400864220L;
 
-    private final String jobName;
-    private final String jobNumber;
-    private final String jobUser;
-    private final String to;
-    private boolean clearTo;
+	private final String jobName;
+	private final String jobNumber;
+	private final String jobUser;
+	private final String to;
+	private boolean clearTo;
 
-    @DataBoundConstructor
-    public IBMiGetSpooledFilesStep(final String jobName, final String jobNumber, final String jobUser,
-                                   final String to) {
-        this.jobName = jobName.trim().toUpperCase();
-        this.jobUser = jobUser.trim().toUpperCase();
-        this.jobNumber = jobNumber.trim().toUpperCase();
-        this.to = to;
-    }
+	@DataBoundConstructor
+	public IBMiGetSpooledFilesStep(final String jobName, final String jobNumber, final String jobUser,
+	                               final String to) {
+		this.jobName = jobName.trim().toUpperCase();
+		this.jobUser = jobUser.trim().toUpperCase();
+		this.jobNumber = jobNumber.trim().toUpperCase();
+		this.to = to;
+	}
 
-    public String getJobName() {
-        return jobName;
-    }
+	public String getJobName() {
+		return jobName;
+	}
 
-    public String getJobNumber() {
-        return jobNumber;
-    }
+	public String getJobNumber() {
+		return jobNumber;
+	}
 
-    public String getJobUser() {
-        return jobUser;
-    }
+	public String getJobUser() {
+		return jobUser;
+	}
 
-    public String getTo() {
-        return to;
-    }
+	public String getTo() {
+		return to;
+	}
 
-    @DataBoundSetter
-    public void setClearTo(final boolean clearTo) {
-        this.clearTo = clearTo;
-    }
+	public boolean isClearTo() {
+		return clearTo;
+	}
 
-    public boolean isClearTo() {
-        return clearTo;
-    }
+	@DataBoundSetter
+	public void setClearTo(final boolean clearTo) {
+		this.clearTo = clearTo;
+	}
 
-    @Override
-    protected SpooledFiles runOnIBMi(final StepContext stepContext, final LoggerWrapper logger, final IBMi ibmi)
-            throws Exception {
-        logger.log(Messages.IBMiGetSpooledFiles_getting(jobNumber, jobUser, jobName));
-        final SpooledFiles spooledFiles = listSpooledFiles(ibmi);
+	@Override
+	protected SpooledFiles runOnIBMi(final StepContext stepContext, final LoggerWrapper logger, final IBMi ibmi)
+			throws Exception {
+		logger.log(Messages.IBMiGetSpooledFiles_getting(jobNumber, jobUser, jobName));
+		final SpooledFiles spooledFiles = listSpooledFiles(ibmi);
 
-        final FilePath toFolder = stepContext.get(FilePath.class).child(to);
-        if (toFolder.exists() && clearTo) {
-            toFolder.deleteContents();
-            logger.trace("Cleared target directory %s", toFolder);
-        }
-        toFolder.mkdirs();
+		final FilePath toFolder = stepContext.get(FilePath.class).child(to);
+		if (toFolder.exists() && clearTo) {
+			toFolder.deleteContents();
+			logger.trace("Cleared target directory %s", toFolder);
+		}
+		toFolder.mkdirs();
 
-        final IFSFile tempDirectory = new IFSFile(ibmi.getIbmiConnection(),
-                "/tmp",
-                UUID.randomUUID() + ".jenkins.temp");
-        try {
-            final IFSFile workDirectory = new IFSFile(tempDirectory, "work");
-            workDirectory.mkdirs();
-            logger.trace("Created work directory %s", workDirectory);
+		for (final SpooledFiles.SpooledFile spooledFile : spooledFiles) {
+			final FilePath toFile = toFolder.child(spooledFile.getFileName());
+			logger.trace(MessageFormat.format("Writing {0} ({1}) into {2}", spooledFile.getName(), spooledFile.getNumber(), toFile));
+			toFile.write(readSpooledFile(ibmi, spooledFile), StandardCharsets.UTF_8.name());
+		}
 
-            for (final SpooledFiles.SpooledFile spooledFile : spooledFiles) {
-                final IFSFile workFile = new IFSFile(workDirectory, spooledFile.getFileName());
-                final CallResult cpysplf = ibmi
-                        .executeCommand(String.format(
-                                "CPYSPLF FILE(%s) SPLNBR(%s) TOFILE(*TOSTMF) JOB(%s/%s/%s) TOSTMF('%s/%s')",
-                                spooledFile.getName(), spooledFile.getNumber(),
-                                spooledFile.getJobNumber(), spooledFile.getJobUser(), spooledFile.getJobName(),
-                                workDirectory, spooledFile.getFileName()));
-                if (!cpysplf.isSuccessful()) {
-                    throw new AbortException(Messages.IBMiGetSpooledFiles_cpysplf_failed(cpysplf.getPrettyMessages()));
-                }
+		logger.log(Messages.IBMiGetSpooledFiles_count(spooledFiles.size(), toFolder));
+		return spooledFiles;
+	}
 
-                final IFSFile targetFile = new IFSFile(tempDirectory, spooledFile.getFileName());
-                final CallResult cpy = ibmi
-                        .executeCommand(String.format("CPY OBJ('%s') TOOBJ('%s') TOCCSID(1208) DTAFMT(*TEXT)",
-                                workFile, targetFile));
-                if (!cpy.isSuccessful()) {
-                    throw new AbortException(Messages.IBMiGetSpooledFiles_cpy_failed(cpy.getPrettyMessages()));
-                }
+	private SpooledFiles listSpooledFiles(final IBMi ibmi)
+			throws SQLException, AS400SecurityException, ObjectDoesNotExistException, IOException, InterruptedException,
+			ErrorCompletingRequestException {
+		final SpooledFiles spooledFiles = new SpooledFiles();
+		ibmi.executeAndProcessQuery(String.format(
+						"Select SPOOLED_FILE_NAME, SPOOLED_FILE_NUMBER, SIZE, USER_DATA, JOB_NAME, JOB_USER, JOB_NUMBER " +
+								"From Table(QSYS2.SPOOLED_FILE_INFO(JOB_NAME => '%s/%s/%s', STATUS => '*READY'))",
+						jobNumber, jobUser, jobName),
+				row -> {
+					final SpooledFiles.SpooledFile spooledFile = new SpooledFiles.SpooledFile(
+							row.getString("SPOOLED_FILE_NAME"),
+							row.getInt("SPOOLED_FILE_NUMBER"),
+							row.getLong("SIZE"), row.getString("USER_DATA"),
+							row.getString("JOB_NAME"), row.getString("JOB_USER"), row.getString("JOB_NUMBER"));
 
-                final FilePath toFile = toFolder.child(spooledFile.getFileName());
-                logger.trace(MessageFormat.format("Downloading {0} into {1}", targetFile, toFile));
-                ibmi.download(targetFile, toFile);
-            }
-        } finally {
-            final CallResult clear = ibmi.executeCommand(String.format("RMVDIR DIR('%s') SUBTREE(*ALL)",
-                    tempDirectory.getAbsolutePath()));
-            if (!clear.isSuccessful()) {
-                logger.trace("Failed to clear temporary directory %s: %s",
-                        tempDirectory,
-                        clear.getPrettyMessages());
-            }
-        }
+					if (spooledFile.exists()) {
+						spooledFiles.add(spooledFile);
+					}
+				});
 
-        logger.log(Messages.IBMiGetSpooledFiles_count(spooledFiles.size(), toFolder));
-        return spooledFiles;
-    }
+		return spooledFiles;
+	}
 
-    private SpooledFiles listSpooledFiles(final IBMi ibmi)
-            throws SQLException, AS400SecurityException, ObjectDoesNotExistException, IOException, InterruptedException,
-            ErrorCompletingRequestException {
-        final SpooledFiles spooledFiles = new SpooledFiles();
-        ibmi.executeAndProcessQuery(String.format(
-                        "Select SPOOLED_FILE_NAME, SPOOLED_FILE_NUMBER, SIZE, USER_DATA, JOB_NAME, JOB_USER, JOB_NUMBER " +
-                                "From Table(QSYS2.SPOOLED_FILE_INFO(JOB_NAME => '%s/%s/%s', STATUS => '*READY'))",
-                        jobNumber, jobUser, jobName),
-                row -> {
-                    final SpooledFiles.SpooledFile spooledFile = new SpooledFiles.SpooledFile(
-                            row.getString("SPOOLED_FILE_NAME"),
-                            row.getInt("SPOOLED_FILE_NUMBER"),
-                            row.getLong("SIZE"), row.getString("USER_DATA"),
-                            row.getString("JOB_NAME"), row.getString("JOB_USER"), row.getString("JOB_NUMBER"));
+	private String readSpooledFile(final IBMi ibmi, final SpooledFiles.SpooledFile spooledFile) throws SQLException, AS400SecurityException, ObjectDoesNotExistException, IOException, InterruptedException, ErrorCompletingRequestException {
+		final List<String> lines = new ArrayList<>();
+		ibmi.executeAndProcessQuery(String.format("select RTRIM(SPOOLED_DATA) from table(SYSTOOLS.spooled_file_data(job_name => '%s/%s/%s', SPOOLED_FILE_NAME => '%s', SPOOLED_FILE_NUMBER => %s))",
+						spooledFile.getJobNumber(), spooledFile.getJobUser(), spooledFile.getJobName(),
+						spooledFile.getName(), spooledFile.getNumber()),
+				row -> lines.add(row.getString(1)));
 
-                    if (spooledFile.exists()) {
-                        spooledFiles.add(spooledFile);
-                    }
-                });
+		return String.join("\n", lines);
+	}
 
-        return spooledFiles;
-    }
+	@Extension
+	public static class DescriptorImpl extends IBMiStepDescriptor {
 
-    @Extension
-    public static class DescriptorImpl extends IBMiStepDescriptor {
+		@Override
+		public String getFunctionName() {
+			return "ibmiGetSPLF";
+		}
 
-        @Override
-        public String getFunctionName() {
-            return "ibmiGetSPLF";
-        }
-
-        @Override
-        public String getDisplayName() {
-            return Messages.IBMiGetSpooledFiles_description();
-        }
-    }
+		@Override
+		@NonNull
+		public String getDisplayName() {
+			return Messages.IBMiGetSpooledFiles_description();
+		}
+	}
 }

--- a/src/main/java/org/jenkinsci/plugins/ibmisteps/steps/IBMiPutSAVFStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ibmisteps/steps/IBMiPutSAVFStep.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.ibmisteps.steps;
 import com.ibm.as400.access.AS400SecurityException;
 import com.ibm.as400.access.ErrorCompletingRequestException;
 import com.ibm.as400.access.SaveFile;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.FilePath;
@@ -83,6 +84,7 @@ public class IBMiPutSAVFStep extends IBMiStep<SaveFileContent> {
             return "ibmiPutSAVF";
         }
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.IBMiUploadSAVF_description();

--- a/src/main/java/org/jenkinsci/plugins/ibmisteps/steps/OnIBMiStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ibmisteps/steps/OnIBMiStep.java
@@ -186,7 +186,7 @@ public class OnIBMiStep extends Step implements Serializable {
 		}
 
 		@Override
-		public void expand(@NonNull final EnvVars env) throws IOException, InterruptedException {
+		public void expand(@NonNull final EnvVars env) {
 			env.putAll(ibmiEnvVars);
 		}
 

--- a/src/main/java/org/jenkinsci/plugins/ibmisteps/steps/OnIBMiStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ibmisteps/steps/OnIBMiStep.java
@@ -1,37 +1,9 @@
 package org.jenkinsci.plugins.ibmisteps.steps;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.text.MessageFormat;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.jenkinsci.plugins.ibmisteps.Messages;
-import org.jenkinsci.plugins.ibmisteps.configuration.IBMiGlobalConfiguration;
-import org.jenkinsci.plugins.ibmisteps.configuration.IBMiServerConfiguration;
-import org.jenkinsci.plugins.ibmisteps.model.IBMi;
-import org.jenkinsci.plugins.ibmisteps.model.IBMiContext;
-import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
-import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
-import org.jenkinsci.plugins.workflow.steps.GeneralNonBlockingStepExecution;
-import org.jenkinsci.plugins.workflow.steps.Step;
-import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
-import org.jenkinsci.plugins.workflow.steps.StepExecution;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.stapler.AncestorInPath;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
-import org.kohsuke.stapler.interceptor.RequirePOST;
-
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.google.common.collect.ImmutableSet;
 import com.ibm.as400.access.AS400SecurityException;
-
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -40,6 +12,26 @@ import hudson.model.Item;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.util.ListBoxModel;
+import org.jenkinsci.plugins.ibmisteps.Messages;
+import org.jenkinsci.plugins.ibmisteps.configuration.IBMiGlobalConfiguration;
+import org.jenkinsci.plugins.ibmisteps.configuration.IBMiServerConfiguration;
+import org.jenkinsci.plugins.ibmisteps.model.IBMi;
+import org.jenkinsci.plugins.ibmisteps.model.IBMiContext;
+import org.jenkinsci.plugins.workflow.steps.*;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.interceptor.RequirePOST;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class OnIBMiStep extends Step implements Serializable {
 	private static final long serialVersionUID = 4356326103523728526L;
@@ -194,7 +186,7 @@ public class OnIBMiStep extends Step implements Serializable {
 		}
 
 		@Override
-		public void expand(final EnvVars env) throws IOException, InterruptedException {
+		public void expand(@NonNull final EnvVars env) throws IOException, InterruptedException {
 			env.putAll(ibmiEnvVars);
 		}
 

--- a/src/main/resources/org/jenkinsci/plugins/ibmisteps/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/ibmisteps/Messages.properties
@@ -20,6 +20,7 @@ IBMi.connected=Connected {4} to {0} (IBM i OS {1}) with profile {2} and CCSID {3
 IBMi.connection.failed=Failed to connect to IBM i: {0}
 IBMi.closeSQL.error=Error occurred while closing SQL connection: {0}
 IBMi.change.iasp.failed=Failed to change current iASP to {0}
+IBMi.failed.sql.service.check=Failed to check SQL Service: {0}
 
 IBMICommandStep.description=Run an IBM i command
 IBMICommandStep.running=Running IBM i command {0}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR replaces the previous single implementation used to list and read the content of a spooled file with two implementations:
- SQL service based implementation
- CL commands / IFS based implementation

The implementation selection is made at runtime, depending on the availability of the `SPOOLED_FILE_DATA` and `SPOOLED_FILE_INFO` SQL services.

SQL service implementation is selected whenever it's available. CL implementation acts as a fallback for pre 7.3 TR 12 LPARs.

### Testing done
Ran a pipeline using the `ibmiGetSPLF` step and checked spooled files were correctly retrieved and written.
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
