### PR TITLE
jetty.port=PORT no longer works. Use mvn hpi:run -Dport=PORT

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ mvn hpi:run
 
 To specify the HTTP port, run:
 ````shell
-mvn hpi:run -Djetty.port=PORT
+mvn hpi:run -Dport=PORT
 ````
 
 ### Debugging

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,4 +47,5 @@ Many thanks to everyone [who has contributed so far](https://github.com/jenkinsc
 
 * [@sebjulliand](https://github.com/sebjulliand)
 * [@strangelookingnerd](https://github.com/strangelookingnerd)
-* [@AbhinavJha1023](https://github.com/https://github.com/AbhinavJha1023)
+* [@AbhinavJha1023](https://github.com/AbhinavJha1023)
+* [@wimjongman](https://github.com/wimjongman)


### PR DESCRIPTION
-Djetty.port=PORT no longer works. Use mvn hpi:run -Dport=PORT